### PR TITLE
separate username and password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/lib/autodiscover/client.rb
+++ b/lib/autodiscover/client.rb
@@ -91,7 +91,7 @@ module Autodiscover
     end
 
     def try_secure_url(url, credentials, req_body)
-      @http.set_auth(url, credentials.email, credentials.password)
+      @http.set_auth(url, credentials.username, credentials.password)
 
       response = @http.post(url, req_body, {'Content-Type' => 'text/xml; charset=utf-8'}) rescue nil
       return nil unless response

--- a/lib/autodiscover/credentials.rb
+++ b/lib/autodiscover/credentials.rb
@@ -25,27 +25,19 @@ module Autodiscover
   # A Credentials object is used to determine the autodiscover service
   # endpoint and to authenticate to it.
   class Credentials
-    # E-mail address for the user.
-    attr_reader :email
-
-    # Password for the account.
+    attr_accessor :email
+    attr_reader :username
     attr_reader :password
 
-    # SMTP domain determined by the e-mail address.
-    attr_reader :smtp_domain  #:nodoc:
-
-    def initialize(address, password)
-      self.email = address
+    def initialize(email, username, password)
+      @email = email
+      @username = username
       @password = password
     end
 
-    def email=(address)  #:nodoc:
-      raise ArgumentError, "No email address specified" unless address
-      @smtp_domain = address[/^.+@(.*)$/, 1]
-      unless @smtp_domain =~ /.+\..+/
-        raise ArgumentError, "Invalid email address: #{address}"
-      end
-      @email = address
+    # SMTP domain determined by the e-mail address.
+    def smtp_domain
+      email[/^.+@(.*)$/, 1]
     end
   end
 end

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -58,7 +58,7 @@ END
 
 class AutodiscoverResponseTest < Test::Unit::TestCase
   def setup
-    @credentials = Autodiscover::Credentials.new('spiff@spacecommand.sol', 'hobbes')
+    @credentials = Autodiscover::Credentials.new('spiff@spacecommand.sol', 'spiff@spacecommand.sol', 'hobbes')
     @client = Autodiscover::Client.new
     WebMock::stub_request(:any, /spacecommand.sol/).to_timeout
   end
@@ -140,7 +140,7 @@ class AutodiscoverResponseTest < Test::Unit::TestCase
       :status => 200, 
       :headers => { 'Content-Length' => REDIRECTURL_AUTODISCOVER_RESPONSE.size }
     )
-    WebMock::stub_request(:post, 'https://calvin%40spacecommand.sol:hobbes@spacecommand.sol/autodiscover/autodiscover.xml').to_return(
+    WebMock::stub_request(:post, 'https://spiff%40spacecommand.sol:hobbes@spacecommand.sol/autodiscover/autodiscover.xml').to_return(
       :body => SETTINGS_AUTODISCOVER_RESPONSE,
       :status => 200, 
       :headers => { 'Content-Length' => SETTINGS_AUTODISCOVER_RESPONSE.size }


### PR DESCRIPTION
The correct behavior (as I have observed through testing) is to separate the username and email in the credentials. When a `redirectAddr` is encountered, it should change the email but preserve the original username.
