### PR TITLE
Press on if ECONNREFUSED

### DIFF
--- a/lib/autodiscover/pox_request.rb
+++ b/lib/autodiscover/pox_request.rb
@@ -19,7 +19,7 @@ module Autodiscover
         begin
           response = client.http.post(url, request_body, {'Content-Type' => 'text/xml; charset=utf-8'})
           return PoxResponse.new(response.body) if good_response?(response)
-        rescue Errno::ENETUNREACH
+        rescue Errno::ENETUNREACH, Errno::ECONNREFUSED
           next
         rescue OpenSSL::SSL::SSLError
           options[:ignore_ssl_errors] ? next : raise


### PR DESCRIPTION
When attempting an autodiscover on a Rackspace Hosted Exchange account we get a ECONNREFUSED error when attempting to hit `https://autodiscover.#{client.domain}/autodiscover/autodiscover.xml`.  If we press on from this error the `redirected_http_url` works properly.
