### PR TITLE
Added the ability to set the connection timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ client = Autodiscover::Client.new(email: "blumbergh@initech.local", password: "t
 # Override the domain
 client = Autodiscover::Client.new(email: "blumbergh@initech.local", password: "tps_eq_awesome", domain: "tpsreports.local")
 
+# Set a custom connection timeout
+client = Autodiscover::Client.new(email: "blumbergh@initech.local", password: "tps_eq_awesome", connect_timeout: 5)
+
 # Ignore SSL Errors
 client.autodiscover(ignore_ssl_errors: true)
 ```

--- a/lib/autodiscover/client.rb
+++ b/lib/autodiscover/client.rb
@@ -1,6 +1,6 @@
 module Autodiscover
   class Client
-
+    DEFAULT_HTTP_TIMEOUT = 10
     attr_reader :domain, :email, :http
 
     # @param email [String] An e-mail to use for autodiscovery. It will be
@@ -10,7 +10,7 @@ module Autodiscover
     #   with something other than the e-mail. For instance DOMAIN\user
     # @param domain [String] An optional domain to provide as an override for
     #   the one parsed from the e-mail.
-    def initialize(email:, password:, username: nil, domain: nil, connect_timeout: nil)
+    def initialize(email:, password:, username: nil, domain: nil, connect_timeout: DEFAULT_HTTP_TIMEOUT)
       @email = email
       @domain = domain || @email.split("@").last
       @http = HTTPClient.new

--- a/lib/autodiscover/client.rb
+++ b/lib/autodiscover/client.rb
@@ -10,10 +10,11 @@ module Autodiscover
     #   with something other than the e-mail. For instance DOMAIN\user
     # @param domain [String] An optional domain to provide as an override for
     #   the one parsed from the e-mail.
-    def initialize(email:, password:, username: nil, domain: nil)
+    def initialize(email:, password:, username: nil, domain: nil, connect_timeout: nil)
       @email = email
       @domain = domain || @email.split("@").last
       @http = HTTPClient.new
+      @http.connect_timeout = connect_timeout if connect_timeout
       @username = username || email
       @http.set_auth(nil, @username, password)
     end

--- a/lib/autodiscover/pox_request.rb
+++ b/lib/autodiscover/pox_request.rb
@@ -19,7 +19,7 @@ module Autodiscover
         begin
           response = client.http.post(url, request_body, {'Content-Type' => 'text/xml; charset=utf-8'})
           return PoxResponse.new(response.body) if good_response?(response)
-        rescue Errno::ENETUNREACH, Errno::ECONNREFUSED
+        rescue Errno::ENETUNREACH, Errno::ECONNREFUSED, HTTPClient::ConnectTimeoutError
           next
         rescue OpenSSL::SSL::SSLError
           options[:ignore_ssl_errors] ? next : raise


### PR DESCRIPTION
For some reason, recently,  the request to autodiscover.outlook.com over HTTPS has been timing out.  I would expect it to fail to connect immediately (and it used to).  I think it makes sense to be able to specify a desired connection timeout.  I left the default as is (which is 60 seconds for HttpClient).
