### PR TITLE
Handle Exchange 2013 SP1 correctly (based on build number)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 mkmf.log
 scratch.rb
 *.sw[op]
+.idea

--- a/lib/autodiscover/errors.rb
+++ b/lib/autodiscover/errors.rb
@@ -2,4 +2,5 @@ module Autodiscover
   class Error < ::StandardError; end
 
   class ArgumentError < Error; end
+  class VersionError < Error; end
 end

--- a/lib/autodiscover/server_version_parser.rb
+++ b/lib/autodiscover/server_version_parser.rb
@@ -16,6 +16,7 @@ module Autodiscover
       15 => {
         0 => 'Exchange2013', # Minor builds starting from 847 are Exchange2013_SP1
         1 => 'Exchange2016',
+        2 => 'Exchange2019',
         20 => 'Exchange2016' # This is Office365
       }
     }.freeze
@@ -37,7 +38,9 @@ module Autodiscover
     end
 
     def exchange_version
-      version = VERSIONS[major][minor] || VERSIONS[8][0]
+      version = VERSIONS[major][minor]
+      raise Autodiscover::VersionError, "Unknown version string: #{@version}" unless version
+
       version = 'Exchange2013_SP1' if version == 'Exchange2013' && build >= 847
       version
     end

--- a/lib/autodiscover/server_version_parser.rb
+++ b/lib/autodiscover/server_version_parser.rb
@@ -1,27 +1,27 @@
 module Autodiscover
   class ServerVersionParser
-
     VERSIONS = {
       8 => {
-        0 => "Exchange2007",
-        1 => "Exchange2007_SP1",
-        2 => "Exchange2007_SP1",
-        3 => "Exchange2007_SP1",
+        0 => 'Exchange2007',
+        1 => 'Exchange2007_SP1',
+        2 => 'Exchange2007_SP1',
+        3 => 'Exchange2007_SP1'
       },
       14 => {
-        0 => "Exchange2010",
-        1 => "Exchange2010_SP1",
-        2 => "Exchange2010_SP2",
-        3 => "Exchange2010_SP2",
+        0 => 'Exchange2010',
+        1 => 'Exchange2010_SP1',
+        2 => 'Exchange2010_SP2',
+        3 => 'Exchange2010_SP2'
       },
       15 => {
-        0 => "Exchange2013",
-        1 => "Exchange2013_SP1",
+        0 => 'Exchange2013', # Minor builds starting from 847 are Exchange2013_SP1
+        1 => 'Exchange2016',
+        20 => 'Exchange2016' # This is Office365
       }
-    }
+    }.freeze
 
     def initialize(hexversion)
-      @version = hexversion.hex.to_s(2).rjust(hexversion.size*4, '0')
+      @version = hexversion.hex.to_s(2).rjust(hexversion.size * 4, '0')
     end
 
     def major
@@ -37,9 +37,9 @@ module Autodiscover
     end
 
     def exchange_version
-      v = VERSIONS[major][minor]
-      v.nil? ? VERIONS[8][0] : v
+      version = VERSIONS[major][minor] || VERSIONS[8][0]
+      version = 'Exchange2013_SP1' if version == 'Exchange2013' && build >= 847
+      version
     end
-
   end
 end

--- a/lib/autodiscover/version.rb
+++ b/lib/autodiscover/version.rb
@@ -1,3 +1,3 @@
 module Autodiscover
-  VERSION = "1.0.2"
+  VERSION = '1.0.3'.freeze
 end


### PR DESCRIPTION
To detect Exchange 2013 SP1 correctly, we need to also check the build number!