### PR TITLE
Fix lint offenses and enforce lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    # Advisory-only for the modernize first pass: lint failures do not block CI.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
RuboCop already reports zero offenses across the repo (16 files inspected), so this PR simply drops `continue-on-error: true` from the lint job in `.github/workflows/ci.yml`, making lint a required CI check going forward.

- Verified locally with RuboCop 1.91.0 (the version CI installs, unpinned in the Gemfile): `16 files inspected, no offenses detected`
- `Gemspec/RequiredRubyVersion` is already excluded in `.rubocop.yml` (gemspec floors are intentionally low), so no gemspec change is needed
- No Ruby code was touched, so no behavior-change risk